### PR TITLE
Lib data tombstones

### DIFF
--- a/here-naksha-cli/src/jvmMain/java/com/here/naksha/cli/storages/GeneratingSession.java
+++ b/here-naksha-cli/src/jvmMain/java/com/here/naksha/cli/storages/GeneratingSession.java
@@ -111,25 +111,33 @@ final class GeneratingSession implements IReadSession {
 
     @Nullable
     @Override
-    public NakshaCatalog getCatalogById(@NotNull String mapId) {
+    public NakshaCatalog getCatalogById(@NotNull String mapId, boolean allowTombstone) {
         throw new NakshaException(NakshaError.UNSUPPORTED_OPERATION, "");
     }
 
     @Nullable
     @Override
-    public NakshaCatalog getCatalogByNumber(int catalogNumber) {
+    public NakshaCatalog getCatalogByNumber(int catalogNumber, boolean allowTombstone) {
         throw new NakshaException(NakshaError.UNSUPPORTED_OPERATION, "");
     }
 
     @Nullable
     @Override
-    public NakshaCollection getCollectionById(@NotNull NakshaCatalog map, @NotNull String collectionId) {
+    public NakshaCollection getCollectionById(
+        @NotNull NakshaCatalog map,
+        @NotNull String collectionId,
+        boolean allowTombstone
+    ) {
         throw new NakshaException(NakshaError.UNSUPPORTED_OPERATION, "");
     }
 
     @Nullable
     @Override
-    public NakshaCollection getCollectionByNumber(@NotNull NakshaCatalog catalog, int collectionNumber) {
+    public NakshaCollection getCollectionByNumber(
+        @NotNull NakshaCatalog catalog,
+        int collectionNumber,
+        boolean allowTombstone
+    ) {
         throw new NakshaException(NakshaError.UNSUPPORTED_OPERATION, "");
     }
 

--- a/here-naksha-lib-base/src/commonMain/kotlin/naksha/base/TupleNumber.kt
+++ b/here-naksha-lib-base/src/commonMain/kotlin/naksha/base/TupleNumber.kt
@@ -74,6 +74,13 @@ data class TupleNumber(
         get() = Action.fromValue(version.toInt() and 3)
 
     /**
+     * Tests if the `Tuple` is a tombstone, so a deleted state.
+     * @since 3.0
+     */
+    val isDeleted: Boolean
+        get() = action == Action.DELETE
+
+    /**
      * Calculates the distribution partition-index where this [naksha.model.Tuple] will be located.
      *
      * If the given partitions are less than `2`, the method always returns `-1`. If the number is bigger than `65536` the result will be mapped back into the range between `0` and `65536` _(exclusive)_.

--- a/here-naksha-lib-base/src/commonMain/kotlin/naksha/base/Version.kt
+++ b/here-naksha-lib-base/src/commonMain/kotlin/naksha/base/Version.kt
@@ -305,7 +305,7 @@ open class Version(@JvmField val number: Int64) : Comparable<Version> {
          */
         @JsStatic
         @JvmStatic
-        fun isCREATE(version: Int64): Boolean = (version.toLong() and -4L).toInt() == CREATE.intValue
+        fun isCREATE(version: Int64): Boolean = (version.toLong() and 3L).toInt() == CREATE.intValue
 
         /**
          * Tests if the given version encodes the [UPDATE] action.
@@ -315,7 +315,7 @@ open class Version(@JvmField val number: Int64) : Comparable<Version> {
          */
         @JsStatic
         @JvmStatic
-        fun isUPDATE(version: Int64): Boolean = (version.toLong() and -4L).toInt() == UPDATE.intValue
+        fun isUPDATE(version: Int64): Boolean = (version.toLong() and 3L).toInt() == UPDATE.intValue
 
         /**
          * Tests if the given version encodes the [DELETE] action.
@@ -325,7 +325,7 @@ open class Version(@JvmField val number: Int64) : Comparable<Version> {
          */
         @JsStatic
         @JvmStatic
-        fun isDELETE(version: Int64): Boolean = (version.toLong() and -4L).toInt() == DELETE.intValue
+        fun isDELETE(version: Int64): Boolean = (version.toLong() and 3L).toInt() == DELETE.intValue
 
         /**
          * Tests if the given version encodes the [VERSION] action.
@@ -335,7 +335,7 @@ open class Version(@JvmField val number: Int64) : Comparable<Version> {
          */
         @JsStatic
         @JvmStatic
-        fun isVERSION(version: Int64): Boolean = (version.toLong() and -4L).toInt() == VERSION.intValue
+        fun isVERSION(version: Int64): Boolean = (version.toLong() and 3L).toInt() == VERSION.intValue
     }
 
     private var _year = -1

--- a/here-naksha-lib-base/src/commonMain/kotlin/naksha/base/Version.kt
+++ b/here-naksha-lib-base/src/commonMain/kotlin/naksha/base/Version.kt
@@ -2,6 +2,10 @@
 
 package naksha.base
 
+import naksha.base.Action.Action_C.CREATE
+import naksha.base.Action.Action_C.DELETE
+import naksha.base.Action.Action_C.UPDATE
+import naksha.base.Action.Action_C.VERSION
 import kotlin.js.JsExport
 import kotlin.js.JsName
 import kotlin.js.JsStatic
@@ -221,7 +225,7 @@ open class Version(@JvmField val number: Int64) : Comparable<Version> {
          */
         @JvmField
         @JsStatic
-        val MIN_AUTO = auto(16, 1, 1, Int64(0), Action.CREATE)
+        val MIN_AUTO = auto(16, 1, 1, Int64(0), CREATE)
         // 0n + (0n << 2n) + (1n << 32n) + (1n << (32n+5n)) + (16n << (32n+5n+4n)) = 35326106009600n
         // bitwise: 0x0000_2021_0000_0000
 
@@ -231,7 +235,7 @@ open class Version(@JvmField val number: Int64) : Comparable<Version> {
          */
         @JvmField
         @JsStatic
-        val MAX_AUTO = auto(4095, 12, 31, Int64(1_073_741_823), Action.VERSION)
+        val MAX_AUTO = auto(4095, 12, 31, Int64(1_073_741_823), VERSION)
         // 3n + (1073741823n << 2n) + (31n << 32n) + (12n << (32n+5n)) + (4095n << (32n+5n+4n)) = 9006786937880575n
         // bitwise: 0x001f_ff9f_ffff_ffff
 
@@ -241,7 +245,7 @@ open class Version(@JvmField val number: Int64) : Comparable<Version> {
          */
         @JvmField
         @JsStatic
-        val MIN_MANUAL = manual(Int64(1), Action.CREATE)
+        val MIN_MANUAL = manual(Int64(1), CREATE)
 
         /**
          * The maximum valid manual version (seq=2,199,023,255,551, action=VERSION).
@@ -249,7 +253,7 @@ open class Version(@JvmField val number: Int64) : Comparable<Version> {
          */
         @JvmField
         @JsStatic
-        val MAX_MANUAL = manual(MANUAL_SEQ_MASK, Action.CREATE)
+        val MAX_MANUAL = manual(MANUAL_SEQ_MASK, CREATE)
 
         /**
          * The absolute minimum version number _(3)_.
@@ -292,6 +296,46 @@ open class Version(@JvmField val number: Int64) : Comparable<Version> {
         @JvmField
         @JsStatic
         val SEQ_INC: Int64 = Int64(1) shl 2
+
+        /**
+         * Tests if the given version encodes the [CREATE] action.
+         * @param version the version to test.
+         * @return _true_ if the encoded [Action] is [CREATE].
+         * @since 3.0
+         */
+        @JsStatic
+        @JvmStatic
+        fun isCREATE(version: Int64): Boolean = (version.toLong() and -4L).toInt() == CREATE.intValue
+
+        /**
+         * Tests if the given version encodes the [UPDATE] action.
+         * @param version the version to test.
+         * @return _true_ if the encoded [Action] is [UPDATE].
+         * @since 3.0
+         */
+        @JsStatic
+        @JvmStatic
+        fun isUPDATE(version: Int64): Boolean = (version.toLong() and -4L).toInt() == UPDATE.intValue
+
+        /**
+         * Tests if the given version encodes the [DELETE] action.
+         * @param version the version to test.
+         * @return _true_ if the encoded [Action] is [DELETE].
+         * @since 3.0
+         */
+        @JsStatic
+        @JvmStatic
+        fun isDELETE(version: Int64): Boolean = (version.toLong() and -4L).toInt() == DELETE.intValue
+
+        /**
+         * Tests if the given version encodes the [VERSION] action.
+         * @param version the version to test.
+         * @return _true_ if the encoded [Action] is [VERSION].
+         * @since 3.0
+         */
+        @JsStatic
+        @JvmStatic
+        fun isVERSION(version: Int64): Boolean = (version.toLong() and -4L).toInt() == VERSION.intValue
     }
 
     private var _year = -1

--- a/here-naksha-lib-hub/src/jvmMain/java/com/here/naksha/lib/hub/storages/NHAdminStorageReader.java
+++ b/here-naksha-lib-hub/src/jvmMain/java/com/here/naksha/lib/hub/storages/NHAdminStorageReader.java
@@ -111,8 +111,8 @@ public class NHAdminStorageReader implements IReadSession {
   }
 
   @Override
-  public @Nullable NakshaCatalog getCatalogById(@NotNull String catalogId) {
-    return session.getCatalogById(catalogId);
+  public @Nullable NakshaCatalog getCatalogById(@NotNull String catalogId, boolean allowTombstone) {
+    return session.getCatalogById(catalogId, allowTombstone);
   }
 
   @Override
@@ -121,13 +121,16 @@ public class NHAdminStorageReader implements IReadSession {
   }
 
   @Override
-  public @Nullable NakshaCatalog getCatalogByNumber(int catalogNumber) {
-    return session.getCatalogByNumber(catalogNumber);
+  public @Nullable NakshaCatalog getCatalogByNumber(int catalogNumber, boolean allowTombstone) {
+    return session.getCatalogByNumber(catalogNumber, allowTombstone);
   }
 
   @Override
-  public @Nullable NakshaCollection getCollectionById(@NotNull NakshaCatalog map, @NotNull String collectionId) {
-    return session.getCollectionById(map, collectionId);
+  public @Nullable NakshaCollection getCollectionById(
+      @NotNull NakshaCatalog map,
+      @NotNull String collectionId,
+      boolean allowTombstone) {
+    return session.getCollectionById(map, collectionId, allowTombstone);
   }
 
   @Override
@@ -136,7 +139,10 @@ public class NHAdminStorageReader implements IReadSession {
   }
 
   @Override
-  public @Nullable NakshaCollection getCollectionByNumber(@NotNull NakshaCatalog catalog, int collectionNumber) {
-    return session.getCollectionByNumber(catalog, collectionNumber);
+  public @Nullable NakshaCollection getCollectionByNumber(
+      @NotNull NakshaCatalog catalog,
+      int collectionNumber,
+      boolean allowTombstone) {
+    return session.getCollectionByNumber(catalog, collectionNumber, allowTombstone);
   }
 }

--- a/here-naksha-lib-hub/src/jvmMain/java/com/here/naksha/lib/hub/storages/NHSpaceStorageReader.java
+++ b/here-naksha-lib-hub/src/jvmMain/java/com/here/naksha/lib/hub/storages/NHSpaceStorageReader.java
@@ -315,7 +315,7 @@ public class NHSpaceStorageReader implements IReadSession {
   }
 
   @Override
-  public @Nullable NakshaCatalog getCatalogById(@NotNull String catalogId) {
+  public @Nullable NakshaCatalog getCatalogById(@NotNull String catalogId, boolean allowTombstone) {
     throw NOT_SUPPORTED_ERROR;
   }
 
@@ -325,12 +325,15 @@ public class NHSpaceStorageReader implements IReadSession {
   }
 
   @Override
-  public @Nullable NakshaCatalog getCatalogByNumber(int catalogNumber) {
+  public @Nullable NakshaCatalog getCatalogByNumber(int catalogNumber, boolean allowTombstone) {
     throw NOT_SUPPORTED_ERROR;
   }
 
   @Override
-  public @Nullable NakshaCollection getCollectionById(@NotNull NakshaCatalog map, @NotNull String collectionId) {
+  public @Nullable NakshaCollection getCollectionById(
+      @NotNull NakshaCatalog map,
+      @NotNull String collectionId,
+      boolean allowTombstone) {
     throw NOT_SUPPORTED_ERROR;
   }
 
@@ -340,7 +343,10 @@ public class NHSpaceStorageReader implements IReadSession {
   }
 
   @Override
-  public @Nullable NakshaCollection getCollectionByNumber(@NotNull NakshaCatalog catalog, int collectionNumber) {
+  public @Nullable NakshaCollection getCollectionByNumber(
+      @NotNull NakshaCatalog catalog,
+      int collectionNumber,
+      boolean allowTombstone) {
     throw NOT_SUPPORTED_ERROR;
   }
 

--- a/here-naksha-lib-hub/src/jvmTest/java/com/here/naksha/lib/hub/mock/NHAdminReaderMock.java
+++ b/here-naksha-lib-hub/src/jvmTest/java/com/here/naksha/lib/hub/mock/NHAdminReaderMock.java
@@ -276,22 +276,28 @@ public class NHAdminReaderMock implements IReadSession {
   }
 
   @Override
-  public @Nullable NakshaCatalog getCatalogById(@NotNull String catalogId) {
+  public @Nullable NakshaCatalog getCatalogById(@NotNull String catalogId, boolean allowTombstone) {
     throw new NakshaException(new NakshaError(NakshaError.UNSUPPORTED_OPERATION, "Not supported by mock yet"));
   }
 
   @Override
-  public @Nullable NakshaCatalog getCatalogByNumber(int catalogNumber) {
+  public @Nullable NakshaCatalog getCatalogByNumber(int catalogNumber, boolean allowTombstone) {
     throw new NakshaException(new NakshaError(NakshaError.UNSUPPORTED_OPERATION, "Not supported by mock yet"));
   }
 
   @Override
-  public @Nullable NakshaCollection getCollectionById(@NotNull NakshaCatalog map, @NotNull String collectionId) {
+  public @Nullable NakshaCollection getCollectionById(
+      @NotNull NakshaCatalog map,
+      @NotNull String collectionId,
+      boolean allowTombstone) {
     throw new NakshaException(new NakshaError(NakshaError.UNSUPPORTED_OPERATION, "Not supported by mock yet"));
   }
 
   @Override
-  public @Nullable NakshaCollection getCollectionByNumber(@NotNull NakshaCatalog catalog, int collectionNumber) {
+  public @Nullable NakshaCollection getCollectionByNumber(
+      @NotNull NakshaCatalog catalog,
+      int collectionNumber,
+      boolean allowTombstone) {
     throw new NakshaException(new NakshaError(NakshaError.UNSUPPORTED_OPERATION, "Not supported by mock yet"));
   }
 

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/ISession.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/ISession.kt
@@ -111,20 +111,22 @@ interface ISession : AutoCloseable {
      *
      * This method does only access the internal caching, and may not be up-to-date. If invoked on a [write session][IWriteSession] before committing changes, it will return catalogs that were created in the current session, but beware that these catalogs may eventually fail to commit.
      * @param catalogId the catalog-id for which to return the latest HEAD state.
+     * @param allowTombstone if tombstones are returned, so _HEAD_ states indicating that the collection was deleted.
      * @return the catalog; _null_ if no such catalog exists.
      * @since 3.0
      */
-    fun getCatalogById(catalogId: String): NakshaCatalog?
+    fun getCatalogById(catalogId: String, allowTombstone: Boolean = false): NakshaCatalog?
 
     /**
      * Returns the catalog for the given number.
      *
      * This method does only access the internal caching, and may not be up-to-date. If invoked on a [write session][IWriteSession] before committing changes, it will return catalogs that were created in the current session, but beware that these catalogs may eventually fail to commit.
      * @param catalogNumber the catalog-number for which to return the latest HEAD state.
+     * @param allowTombstone if tombstones are returned, so _HEAD_ states indicating that the collection was deleted.
      * @return the catalog; _null_ if no such catalog exists.
      * @since 3.0
      */
-    fun getCatalogByNumber(catalogNumber: Int): NakshaCatalog?
+    fun getCatalogByNumber(catalogNumber: Int, allowTombstone: Boolean = false): NakshaCatalog?
 
     /**
      * Returns the collection for the given identifier.
@@ -132,10 +134,11 @@ interface ISession : AutoCloseable {
      * This method does only access the internal caching, and may not be up-to-date. If invoked on a [write session][IWriteSession] before committing changes, it will return collections that were created in the current session, but beware that these collections may eventually fail to commit.
      * @param catalog the catalog to query.
      * @param collectionId the collection-id for which to return the latest HEAD state.
+     * @param allowTombstone if tombstones are returned, so _HEAD_ states indicating that the collection was deleted.
      * @return the collection; _null_ if no such collection exists.
      * @since 3.0
      */
-    fun getCollectionById(catalog: NakshaCatalog, collectionId: String): NakshaCollection?
+    fun getCollectionById(catalog: NakshaCatalog, collectionId: String, allowTombstone: Boolean = false): NakshaCollection?
 
     /**
      * Returns the collection for the given number.
@@ -143,10 +146,11 @@ interface ISession : AutoCloseable {
      * This method does only access the internal caching, and may not be up-to-date. If invoked on a [write session][IWriteSession] before committing changes, it will return collections that were created in the current session, but beware that these collections may eventually fail to commit.
      * @param catalog the catalog to query.
      * @param collectionNumber the collection-number for which to return the latest HEAD state.
+     * @param allowTombstone if tombstones are returned, so _HEAD_ states indicating that the collection was deleted.
      * @return the collection; _null_ if no such collection exists.
      * @since 3.0
      */
-    fun getCollectionByNumber(catalog: NakshaCatalog, collectionNumber: Int): NakshaCollection?
+    fun getCollectionByNumber(catalog: NakshaCatalog, collectionNumber: Int, allowTombstone: Boolean = false): NakshaCollection?
 
      /**
      * Load all tuples into the given [feature-tuples][FeatureTuple].

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/NakshaFeature.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/NakshaFeature.kt
@@ -245,4 +245,14 @@ open class NakshaFeature() : AnyObject() {
      * Human-readable description.
      */
     open var description by DESCRIPTION_NULL
+
+    /**
+     * Tests if this feature is a tombstone, so deleted.
+     * @return _true_ if this feature is a tombstone; _false_ otherwise.
+     * @since 3.0
+     */
+    open fun isDeleted(): Boolean {
+        val guid = this.properties.xyz.guid
+        return guid?.tupleNumber?.isDeleted ?: false
+    }
 }

--- a/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/NakshaFeature.kt
+++ b/here-naksha-lib-model/src/commonMain/kotlin/naksha/model/objects/NakshaFeature.kt
@@ -245,14 +245,4 @@ open class NakshaFeature() : AnyObject() {
      * Human-readable description.
      */
     open var description by DESCRIPTION_NULL
-
-    /**
-     * Tests if this feature is a tombstone, so deleted.
-     * @return _true_ if this feature is a tombstone; _false_ otherwise.
-     * @since 3.0
-     */
-    open fun isDeleted(): Boolean {
-        val guid = this.properties.xyz.guid
-        return guid?.tupleNumber?.isDeleted ?: false
-    }
 }

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgAdminCatalog.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgAdminCatalog.kt
@@ -495,8 +495,17 @@ SELECT basics.*, procs.* FROM basics, procs;
     /**
      * Remove the catalog with the given catalog-number from the cache.
      */
-    protected fun invalidateCatalog(catalog: PgCatalog, atomic: Boolean = true) {
-        if (atomic) catalogCache.remove(catalog.head.catalogNumber, catalog) else catalogCache.remove(catalog.head.catalogNumber)
+    internal fun invalidateCatalog(catalog: PgCatalog, atomic: Boolean = true) {
+        if (atomic) catalogCache.remove(catalog.head.catalogNumber, catalog)
+        else catalogCache.remove(catalog.head.catalogNumber)
+    }
+
+    /**
+     * Invalidate the cache for the catalog with the given number.
+     * @param catalogNumber the number of the catalog to invalidate the cache for.
+     */
+    internal fun invalidateCatalog(catalogNumber: Int) {
+        catalogCache.remove(catalogNumber)
     }
 
     /**

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgAdminCatalog.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgAdminCatalog.kt
@@ -554,7 +554,7 @@ SELECT basics.*, procs.* FROM basics, procs;
         val outRows = PgRows().withCollection(catalogs)
         val SQL = """SELECT ${outRows.aliases()}
 FROM "naksha~admin".${catalogs.headTable.quotedName}
-WHERE $Id = $1 AND (${StandardMembers.FeatureVersion} & 3) < 2"""
+WHERE $Id = $1"""
         val plan = conn.prepare(SQL, arrayOf(PgType.STRING.text))
         plan.execute(arrayOf(id)).fetch().use { cursor ->
             if (!outRows.read(cursor)) return null
@@ -585,7 +585,7 @@ WHERE $Id = $1 AND (${StandardMembers.FeatureVersion} & 3) < 2"""
         val rows = PgRows().withCollection(catalogs)
         val SQL = """SELECT ${rows.aliases()} 
 FROM "naksha~admin".${catalogs.headTable.quotedName} 
-WHERE ${StandardMembers.FeatureNumber} = $1 AND (${StandardMembers.FeatureVersion} & 3) < 2"""
+WHERE ${StandardMembers.FeatureNumber} = $1"""
         setSearchPath(conn)
         val plan = conn.prepare(SQL, arrayOf(PgType.INT64.text))
         plan.execute(arrayOf(number)).fetch().use { rows.readAll(it) }

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgCatalog.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgCatalog.kt
@@ -136,8 +136,17 @@ open class PgCatalog internal constructor(
         } while (true)
     }
 
-    internal fun invalidateCollection(collection: PgCollection) {
-        collectionCache.remove(collection.head.collectionNumber, collection)
+    internal fun invalidateCollection(collection: PgCollection, atomic: Boolean = true) {
+        if (atomic) collectionCache.remove(collection.head.collectionNumber, collection)
+        else collectionCache.remove(collection.head.collectionNumber)
+    }
+
+    /**
+     * Invalidate the cache for the collection with the given number.
+     * @param collectionNumber the number of the collection to invalidate the cache for.
+     */
+    internal fun invalidateCollection(collectionNumber: Int) {
+        collectionCache.remove(collectionNumber)
     }
 
     /**

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgSession.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgSession.kt
@@ -522,7 +522,11 @@ SELECT * FROM from_hst"""
         return found
     }
 
-    override fun getCatalogById(catalogId: String): NakshaCatalog? = getPgCatalogById(catalogId)?.head
+    override fun getCatalogById(catalogId: String, allowTombstone: Boolean): NakshaCatalog? {
+        val catalog = getPgCatalogById(catalogId)?.head ?: return null
+        if (!allowTombstone && catalog.isDeleted()) return null
+        return catalog
+    }
 
     /**
      * Returns the [PgCatalog] for the given id.
@@ -539,7 +543,11 @@ SELECT * FROM from_hst"""
         }
     }
 
-    override fun getCatalogByNumber(catalogNumber: Int): NakshaCatalog? = getPgCatalogByNumber(catalogNumber)?.head
+    override fun getCatalogByNumber(catalogNumber: Int, allowTombstone: Boolean): NakshaCatalog? {
+        val catalog = getPgCatalogByNumber(catalogNumber)?.head ?: return null
+        if (!allowTombstone && catalog.isDeleted()) return null
+        return catalog
+    }
 
     /**
      * Returns the [PgCatalog] for the given number.
@@ -556,9 +564,11 @@ SELECT * FROM from_hst"""
         }
     }
 
-    override fun getCollectionById(catalog: NakshaCatalog, collectionId: String): NakshaCollection? {
+    override fun getCollectionById(catalog: NakshaCatalog, collectionId: String, allowTombstone: Boolean): NakshaCollection? {
         val pgCatalog = getPgCatalogById(catalog.id) ?: return null
-        return getPgCollectionById(pgCatalog, collectionId)?.head
+        val collection = getPgCollectionById(pgCatalog, collectionId)?.head ?: return null
+        if (!allowTombstone && collection.isDeleted()) return null
+        return collection
     }
 
     /**
@@ -576,9 +586,11 @@ SELECT * FROM from_hst"""
         }
     }
 
-    override fun getCollectionByNumber(catalog: NakshaCatalog, collectionNumber: Int): NakshaCollection? {
+    override fun getCollectionByNumber(catalog: NakshaCatalog, collectionNumber: Int, allowTombstone: Boolean): NakshaCollection? {
         val pgCatalog = getPgCatalogById(catalog.id) ?: return null
-        return getPgCollectionByNumber(pgCatalog, collectionNumber)?.head
+        val collection = getPgCollectionByNumber(pgCatalog, collectionNumber)?.head ?: return null
+        if (!allowTombstone && collection.isDeleted()) return null
+        return collection
     }
 
     /**

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgSession.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgSession.kt
@@ -524,7 +524,7 @@ SELECT * FROM from_hst"""
 
     override fun getCatalogById(catalogId: String, allowTombstone: Boolean): NakshaCatalog? {
         val catalog = getPgCatalogById(catalogId)?.head ?: return null
-        if (!allowTombstone && catalog.isDeleted()) return null
+        if (!allowTombstone && (catalog.tupleNumber?.isDeleted ?: false)) return null
         return catalog
     }
 
@@ -545,7 +545,7 @@ SELECT * FROM from_hst"""
 
     override fun getCatalogByNumber(catalogNumber: Int, allowTombstone: Boolean): NakshaCatalog? {
         val catalog = getPgCatalogByNumber(catalogNumber)?.head ?: return null
-        if (!allowTombstone && catalog.isDeleted()) return null
+        if (!allowTombstone && (catalog.tupleNumber?.isDeleted ?: false)) return null
         return catalog
     }
 
@@ -567,7 +567,7 @@ SELECT * FROM from_hst"""
     override fun getCollectionById(catalog: NakshaCatalog, collectionId: String, allowTombstone: Boolean): NakshaCollection? {
         val pgCatalog = getPgCatalogById(catalog.id) ?: return null
         val collection = getPgCollectionById(pgCatalog, collectionId)?.head ?: return null
-        if (!allowTombstone && collection.isDeleted()) return null
+        if (!allowTombstone && (collection.tupleNumber?.isDeleted ?: false)) return null
         return collection
     }
 
@@ -589,7 +589,7 @@ SELECT * FROM from_hst"""
     override fun getCollectionByNumber(catalog: NakshaCatalog, collectionNumber: Int, allowTombstone: Boolean): NakshaCollection? {
         val pgCatalog = getPgCatalogById(catalog.id) ?: return null
         val collection = getPgCollectionByNumber(pgCatalog, collectionNumber)?.head ?: return null
-        if (!allowTombstone && collection.isDeleted()) return null
+        if (!allowTombstone && (collection.tupleNumber?.isDeleted ?: false)) return null
         return collection
     }
 

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgWriter.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgWriter.kt
@@ -140,7 +140,7 @@ open class PgWriter internal constructor(
             }
             // If everything worked out as expected
             if (updateCache != null) {
-                for (pgWrite in pgWrites) {
+                for (pgWrite in updateCache) {
                     val id = pgWrite.id
                     val catalogId = pgWrite.catalog.id
                     if (pgWrite.isCollectionModification) {

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgWriter.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgWriter.kt
@@ -9,6 +9,7 @@ import naksha.base.collectionNotFound
 import naksha.base.forbidden
 import naksha.base.illegalArg
 import naksha.base.illegalState
+import naksha.base.internalError
 import naksha.base.mapExists
 import naksha.base.mapNotFound
 import naksha.model.*
@@ -94,7 +95,7 @@ open class PgWriter internal constructor(
         var partitionSnapshot: Map<PgCollection, Set<Int>>? = null
         try {
             // This can be time-consuming, unless the connection is already open, try not to open it before we do this!
-            prepareWrite(pgWrites)
+            val updateCache = prepareWrite(pgWrites)
 
             // Order by:
             // - catalog-number ASC
@@ -137,7 +138,26 @@ open class PgWriter internal constructor(
                     start = i
                 }
             }
-            // If everything worked out as expected, we can drop the savepoint, if there is any.
+            // If everything worked out as expected
+            if (updateCache != null) {
+                for (pgWrite in pgWrites) {
+                    val id = pgWrite.id
+                    val catalogId = pgWrite.catalog.id
+                    if (pgWrite.isCollectionModification) {
+                        val pgCatalog = session.getPgCatalogById(pgWrite.catalog.id)
+                            ?: throw internalError("The collection '$id' was modified, but the parent catalog '$catalogId' does not exist")
+                        pgCatalog.invalidateCollection(pgWrite.featureNumber.toInt())
+                    } else if (pgWrite.isCatalogModification) {
+                        val pgAdminCatalog = session.getPgCatalogById(pgWrite.catalog.id) as? PgAdminCatalog
+                            ?: throw internalError("The catalog '$id' was modified, but the parent catalog is not the admin-catalog")
+                        pgAdminCatalog.invalidateCatalog(pgWrite.featureNumber.toInt())
+                    } else {
+                        throw internalError("A cache update for '${pgWrite.id}' was reported, but does not match catalog or collection")
+                    }
+                }
+            }
+
+            // We can drop the savepoint, if there is any.
             if (useSavepoint) conn.execute("RELEASE SAVEPOINT \"$savepointId\"").close()
         } catch (t: Throwable) {
             if (conn != null && useSavepoint) {
@@ -188,7 +208,8 @@ open class PgWriter internal constructor(
     // Ensure that the needed physical schema and tables are created.
     // Ensure that the PgTupleWrite data class is ready for action.
     // After this has run, only the `tuple` is missing!
-    private fun prepareWrite(pgWrites: ArrayList<PgWrite>) {
+    private fun prepareWrite(pgWrites: ArrayList<PgWrite>): ArrayList<PgWrite>? {
+        var updateCaches: ArrayList<PgWrite>? = null
         for (pgWrite in pgWrites) {
             val featureId = pgWrite.id
             val op = pgWrite.op
@@ -209,6 +230,10 @@ open class PgWriter internal constructor(
             if (pgWrite.isCatalogModification) {
                 var targetCatalog = storage.adminCatalog.getPgCatalogById(null, pgWrite.id)
                     ?: storage.adminCatalog.getPgCatalogById(conn, pgWrite.id)
+                if (targetCatalog != null && targetCatalog.head.tupleNumber?.isDeleted == true) {
+                    // The catalog is in deleted state, so it does not really exist.
+                    targetCatalog = null
+                }
 
                 val nakshaMap: NakshaCatalog?
                 if (op == WriteOp.CREATE || op == WriteOp.UPSERT || op == WriteOp.UPDATE) {
@@ -234,11 +259,17 @@ open class PgWriter internal constructor(
                 }
                 pgWrite.asPgCatalog = targetCatalog
                 pgWrite.asNakshaMap = nakshaMap
+                if (updateCaches == null) updateCaches = ArrayList()
+                updateCaches.add(pgWrite)
             }
 
             // If this operation modifies a collection.
             if (pgWrite.isCollectionModification) {
                 var targetCollection = pgCatalog.getPgCollectionById(null, pgWrite.id) ?: pgCatalog.getPgCollectionById(conn, pgWrite.id)
+                if (targetCollection != null && targetCollection.head.tupleNumber?.isDeleted == true) {
+                    // The collection is in deleted state, so it does not really exist.
+                    targetCollection = null
+                }
 
                 val nakshaCollection: NakshaCollection?
                 if (op == WriteOp.CREATE || op == WriteOp.UPSERT || op == WriteOp.UPDATE) {
@@ -273,6 +304,8 @@ open class PgWriter internal constructor(
                 }
                 pgWrite.asPgCollection = targetCollection
                 pgWrite.asNakshaCollection = nakshaCollection
+                if (updateCaches == null) updateCaches = ArrayList()
+                updateCaches.add(pgWrite)
             }
             when (op) {
                 WriteOp.CREATE -> {
@@ -317,6 +350,7 @@ open class PgWriter internal constructor(
                 }
             }
         }
+        return updateCaches
     }
 
     /**

--- a/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgWriterDelete.kt
+++ b/here-naksha-lib-psql/src/commonMain/kotlin/naksha/psql/PgWriterDelete.kt
@@ -6,8 +6,6 @@ import naksha.base.PlatformUtil
 import naksha.base.TupleNumber
 import naksha.base.Version
 import naksha.base.conflict
-import naksha.base.featureNotFound
-import naksha.base.generalException
 import naksha.model.objects.MemberType
 import naksha.psql.PgColumn.PgColumn_C.FnColumn
 import naksha.psql.PgColumn.PgColumn_C.NextVersionColumn
@@ -62,22 +60,31 @@ internal class PgWriterDelete(
   SELECT * FROM UNNEST($1, $2) AS t($FnColumn, expected_version)
 )"""
 
-        // Select id and version of all rows matching query.id — used for conflict detection.
-        val head_select = """, head_select AS (
+        // Select `fn` and `version` of all existing rows matching query.`fn`
+        val head_exists = """, head_exists AS (
   SELECT head.$FnColumn AS $FnColumn, head.$VersionColumn AS $VersionColumn
   FROM $headIdent AS head, query
   WHERE head.$FnColumn = query.$FnColumn
 )"""
 
-        // Select the HEAD rows to act on:
-        // - Optional atomic version check (expected_version).
-        // - Skip rows already deleted ((version & 3) >= 2) — idempotent.
+        // Note:
+        // The client can request to delete a feature that actually is already in DELETE state.
+        // If he does this atomically, the operation should always fail.
+        // If he does this non-atomically, we should not move the tombstone into history, because if we would,
+        // we would need to create a new tombstone. However, the feature is already deleted, deleting an already
+        // deleted feature should not fail, but either move the existing HEAD into history.
+        // Removing a tombstone is a PURGE operation, only this will move a tombstone into history and clear
+        // the HEAD.
+        //
+        // Therefore: Select the HEAD rows that are valid to act on:
+        // - Skip rows already deleted ((version & 3) >= 2) - As explained above, a delete must never move tombstones into history!
+        // - If atomic, `expected_version` must match head.`version`, otherwise the row is not legal to operate upon.
         val head_row = """, head_row AS (
   SELECT ${pgCollection.joinColumns { column -> "head.$column AS $column" }}
   FROM $headIdent AS head, query
   WHERE head.$FnColumn = query.$FnColumn
-    AND (query.expected_version IS NULL OR (query.expected_version & -4) = (head.$VersionColumn & -4))
     AND (head.$VersionColumn & 3) < 2
+    AND (query.expected_version IS NULL OR (query.expected_version & -4) = (head.$VersionColumn & -4))
 )"""
 
         // Archive the current HEAD row into history (identical to how UPDATE does it).
@@ -121,7 +128,7 @@ internal class PgWriterDelete(
 
         // The returned row for DELETE is the updated HEAD row (same data, new version/cc).
         // We reconstruct it from head_row overriding the two changed columns.
-        val SQL = """$query$head_select$head_row$head_to_history$head_updated$head_deleted$history_tombstone
+        val SQL = """$query$head_exists$head_row$head_to_history$head_updated$head_deleted$history_tombstone
 SELECT
     head_row.$FnColumn AS $FnColumn,
     $deleted_version AS $VersionColumn,
@@ -130,18 +137,16 @@ SELECT
     ${pgCollection.joinColumns { col -> if (col eq CC || col eq FnColumn || col eq VersionColumn || col eq NextVersionColumn) null else "head_row.$col AS $col" }},
     ${if (head_to_history.isNotEmpty()) "head_to_history.$VersionColumn AS head_history_version," else "null AS head_history_version,"}
     ${if (history_tombstone.isNotEmpty()) "history_tombstone.version AS history_version," else "null AS history_version,"}
-    head_select.$FnColumn AS select_fn,
-    head_select.$VersionColumn AS select_version,
-    head_row.$VersionColumn AS head_version,
+    head_exists.$FnColumn AS existing_fn,
+    head_exists.$VersionColumn AS existing_version,
     ${if (!purge) "head_updated.$VersionColumn AS deleted_version," else "head_deleted.$VersionColumn AS deleted_version,"}
-    query.$FnColumn AS query_fn,
-    query.expected_version AS query_expected_version
+    head_row.$VersionColumn AS head_row_version
 FROM query
 LEFT JOIN head_row ON head_row.$FnColumn = query.$FnColumn
 ${if (!purge) "LEFT JOIN head_updated ON head_updated.$FnColumn = query.$FnColumn" else ""}
 ${if (head_to_history.isNotEmpty()) "LEFT JOIN head_to_history ON head_to_history.$FnColumn = query.$FnColumn" else ""}
 ${if (history_tombstone.isNotEmpty()) "LEFT JOIN history_tombstone ON history_tombstone.$FnColumn = query.$FnColumn" else ""}
-LEFT JOIN head_select ON head_select.$FnColumn = query.$FnColumn
+LEFT JOIN head_exists ON head_exists.$FnColumn = query.$FnColumn
 ${if (purge) "LEFT JOIN head_deleted ON head_deleted.$FnColumn = query.$FnColumn" else ""}
 ;"""
         val typeNames = inRows.typeNames()
@@ -154,12 +159,10 @@ ${if (purge) "LEFT JOIN head_deleted ON head_deleted.$FnColumn = query.$FnColumn
         val outRows = PgRows().withCollection(pgCollection)
         outRows.addColumn("head_history_version", MemberType.INT64)
             .addColumn("history_version", MemberType.INT64)
-            .addColumn("select_fn", MemberType.INT64)
-            .addColumn("select_version", MemberType.INT64)
-            .addColumn("head_version", MemberType.INT64)
+            .addColumn("existing_fn", MemberType.INT64)
+            .addColumn("existing_version", MemberType.INT64)
             .addColumn("deleted_version", MemberType.INT64)
-            .addColumn("query_fn", MemberType.INT64)
-            .addColumn("query_expected_version", MemberType.INT64)
+            .addColumn("head_row_version", MemberType.INT64)
         val plan = plan(conn)
         val array = inRows.values()
         if (PlatformUtil.ENABLE_INFO) {
@@ -183,33 +186,55 @@ ${if (purge) "LEFT JOIN head_deleted ON head_deleted.$FnColumn = query.$FnColumn
         cursor.fetch().use { cursor ->
             outRows.readAll(cursor)
             for (row in 0 until outRows.size) {
-                val write = pgWrites[this.start + row]
-                // query_fn is an int8 column, read as Int64; used only for diagnostics below.
-                val fn = outRows.getInt64(row, "query_fn") ?: throw generalException("Missing 'query_fn' in result")
+                // Take values from input
+                val pgWrite = pgWrites[this.start + row]
+                val id = pgWrite.id
+                //val op = pgWrite.op
+                //val fn = pgWrite.featureNumber
+                val expected_version = pgWrite.version?.number
 
-                val select_fn = outRows.getInt64(row, "select_fn")
-                val select_version = outRows.getInt64(row, "select_version")
-                if (select_fn == null || select_version == null) {
-                    if (write.version != null) {
-                        throw featureNotFound(
-                            "Expected feature '$fn' in version '${write.version}', but no such feature exists"
-                        )
+                // `existing_fn` and `existing_version` are existing rows in HEAD, no matter in what state.
+                // val existing_fn = outRows.getInt64(row, "existing_fn")
+                val existing_version = outRows.getInt64(row, "existing_version")
+
+                // `head_row` selects features that are not in DELETE state and match the expected version.
+                // These are the actual rows the query act upon.
+                // head_row.`version` is the version that was selected from HEAD.
+                // It is NULL:
+                // - If the feature exists, but is DELETE
+                // - If the feature exists, but the client provided `expected_version` and the head_row.`version` differs.
+                val head_row_version = outRows.getInt64(row, "head_row_version")
+                if (head_row_version == null) {
+                    // Nothing was done. This can indicate an error, but not in 100% of the cases.
+
+                    // If the operation was atomic, the client expected a specific state.
+                    if (expected_version != null) {
+                        // As we generally exclude tombstones from processing, to prevent duplicate tombstones in history, the only
+                        // way this is OK is when the existing tombstone is exactly the version the client expected.
+                        // We do not delete the tombstone, only PURGE will do, but we treat this as success still and do not return
+                        // anything.
+                        if (expected_version == existing_version) continue
+
+                        // In all other cases, this is a conflict (unexpected state, failed delete).
+                        if (existing_version == null)
+                            throw conflict("DELETE [$id] failed: Expected feature in version '$expected_version', but no such feature exists")
+                        throw conflict("DELETE [$id] failed: Expected feature in version '$expected_version', but found it in $existing_version")
                     }
+
+                    // The client did not expect any version, non-atomic DELETE operation.
+                    // This means, HEAD is either a soft-delete aka a tombstone or does not exist.
+                    // In both cases this is okay and we return nothing.
                     continue
                 }
-                val head_version = outRows.getInt64(row, "head_version")
-                if (head_version == null || select_version != head_version) {
-                    throw conflict(
-                        "The feature '$fn' was expected in version '${write.version}', but found in '${Version(select_version)}'"
-                    )
-                }
 
+                // We have deleted something and inserted a tombstone into HEAD.
+                // Let's return the deleted feature.
                 val tuple = outRows[row]
-                if (tuple != null) write.tuple = tuple
+                if (tuple != null) pgWrite.tuple = tuple
 
                 val tombstone_fn = outRows.getInt64(row, FnColumn)
                 val tombstone_version = outRows.getInt64(row, VersionColumn)
-                write.tupleNumber = if (tombstone_fn != null && tombstone_version != null) {
+                pgWrite.tupleNumber = if (tombstone_fn != null && tombstone_version != null) {
                     TupleNumber(storageNumber, catalogNumber, collectionNumber, tombstone_fn, tombstone_version)
                 } else null
             }

--- a/here-naksha-lib-psql/src/commonTest/kotlin/naksha/psql/AllowTombstoneTest.kt
+++ b/here-naksha-lib-psql/src/commonTest/kotlin/naksha/psql/AllowTombstoneTest.kt
@@ -13,7 +13,7 @@ import kotlin.test.assertEquals
  * [naksha.model.ISession.getCatalogById] / [naksha.model.ISession.getCollectionById] are called
  * without `allowTombstone = true`), and that they **are** returned when `allowTombstone = true`.
  */
-class AllowTombstoneTest : PgTestBase(collection = null, catalogId = "") {
+class AllowTombstoneTest : PgTestBase() {
 
     @Test
     fun deletedCollectionShouldNotBeReturnedByDefault() {

--- a/here-naksha-lib-psql/src/commonTest/kotlin/naksha/psql/AllowTombstoneTest.kt
+++ b/here-naksha-lib-psql/src/commonTest/kotlin/naksha/psql/AllowTombstoneTest.kt
@@ -7,6 +7,7 @@ import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * Verifies that deleted catalogs and collections are not returned by default (i.e. when
@@ -119,5 +120,33 @@ class AllowTombstoneTest : PgTestBase() {
             assertNotNull(recreated, "Re-created collection MUST be visible after re-creation")
             assertEquals(collectionId, recreated.id, "Re-created collection id must match")
         }
+    }
+
+    @Test
+    fun deletingAlreadyDeletedCollectionShouldSucceed() {
+        val collectionId = "tombstone_double_delete_col_test"
+        val collection = NakshaCollection(collectionId, catalog.id)
+
+        // Create the collection.
+        executeWrite(WriteRequest().add(Write().createCollection(collection)))
+
+        // Delete the collection (first deletion).
+        executeWrite(WriteRequest().add(Write().deleteCollectionById(catalog.id, collectionId)))
+
+        // Fetch the HEAD state including the tombstone and verify it is marked deleted.
+        val tombstone = newWriteSession().use { session ->
+            val cat = session.getCatalogById(catalog.id)
+            assertNotNull(cat, "Catalog should still exist after first deletion")
+            val ts = session.getCollectionById(cat, collectionId, allowTombstone = true)
+            assertNotNull(ts, "Tombstone must be retrievable with allowTombstone = true")
+            assertTrue(
+                ts.tupleNumber?.isDeleted ?: false,
+                "HEAD state must be marked as deleted (tombstone)"
+            )
+            ts
+        }
+
+        // Delete the already-deleted collection again, non-atomically (should succeed).
+        executeWrite(WriteRequest().add(Write().deleteCollection(tombstone, atomic = false)))
     }
 }

--- a/here-naksha-lib-psql/src/commonTest/kotlin/naksha/psql/AllowTombstoneTest.kt
+++ b/here-naksha-lib-psql/src/commonTest/kotlin/naksha/psql/AllowTombstoneTest.kt
@@ -6,6 +6,7 @@ import naksha.model.request.WriteRequest
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertEquals
 
 /**
  * Verifies that deleted catalogs and collections are not returned by default (i.e. when
@@ -83,6 +84,40 @@ class AllowTombstoneTest : PgTestBase(collection = null, catalogId = "") {
                 session.getCatalogById(dedicatedCatalogId, allowTombstone = true),
                 "Deleted catalog MUST be returned when allowTombstone = true"
             )
+        }
+    }
+
+    @Test
+    fun recreatedCollectionShouldBeVisible() {
+        val collectionId = "tombstone_recreate_col_test"
+        val collection = NakshaCollection(collectionId, catalog.id)
+
+        // Create the collection.
+        executeWrite(WriteRequest().add(Write().createCollection(collection)))
+
+        // Delete the collection.
+        executeWrite(WriteRequest().add(Write().deleteCollectionById(catalog.id, collectionId)))
+
+        // Verify the tombstone is present and the collection is not returned by default.
+        newWriteSession().use { session ->
+            val cat = session.getCatalogById(catalog.id)
+            assertNotNull(cat, "Catalog should still exist after collection deletion")
+            assertNull(
+                session.getCollectionById(cat, collectionId),
+                "Deleted collection must NOT be returned when allowTombstone = false (default)"
+            )
+        }
+
+        // Re-create the collection with the same id.
+        executeWrite(WriteRequest().add(Write().createCollection(NakshaCollection(collectionId, catalog.id))))
+
+        // The re-created collection must be visible.
+        newWriteSession().use { session ->
+            val cat = session.getCatalogById(catalog.id)
+            assertNotNull(cat, "Catalog should exist after collection re-creation")
+            val recreated = session.getCollectionById(cat, collectionId)
+            assertNotNull(recreated, "Re-created collection MUST be visible after re-creation")
+            assertEquals(collectionId, recreated.id, "Re-created collection id must match")
         }
     }
 }

--- a/here-naksha-lib-psql/src/commonTest/kotlin/naksha/psql/AllowTombstoneTest.kt
+++ b/here-naksha-lib-psql/src/commonTest/kotlin/naksha/psql/AllowTombstoneTest.kt
@@ -1,0 +1,88 @@
+package naksha.psql
+
+import naksha.model.objects.NakshaCollection
+import naksha.model.request.Write
+import naksha.model.request.WriteRequest
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Verifies that deleted catalogs and collections are not returned by default (i.e. when
+ * [naksha.model.ISession.getCatalogById] / [naksha.model.ISession.getCollectionById] are called
+ * without `allowTombstone = true`), and that they **are** returned when `allowTombstone = true`.
+ */
+class AllowTombstoneTest : PgTestBase(collection = null, catalogId = "") {
+
+    @Test
+    fun deletedCollectionShouldNotBeReturnedByDefault() {
+        val collectionId = "tombstone_col_test"
+        val collection = NakshaCollection(collectionId, catalog.id)
+
+        // Create the collection.
+        executeWrite(WriteRequest().add(Write().createCollection(collection)))
+
+        // Verify it is visible before deletion.
+        newWriteSession().use { session ->
+            val found = session.getCatalogById(catalog.id)
+            assertNotNull(found, "Catalog should exist before deleting the collection")
+            assertNotNull(
+                session.getCollectionById(found, collectionId),
+                "Collection should be visible before deletion"
+            )
+        }
+
+        // Delete the collection.
+        executeWrite(WriteRequest().add(Write().deleteCollectionById(catalog.id, collectionId)))
+
+        // Default call (allowTombstone = false) must return null.
+        newWriteSession().use { session ->
+            val cat = session.getCatalogById(catalog.id)
+            assertNotNull(cat, "Catalog should still exist after collection deletion")
+            assertNull(
+                session.getCollectionById(cat, collectionId),
+                "Deleted collection must NOT be returned when allowTombstone = false (default)"
+            )
+
+            // Explicit allowTombstone = true must return the tombstone entry.
+            assertNotNull(
+                session.getCollectionById(cat, collectionId, allowTombstone = true),
+                "Deleted collection MUST be returned when allowTombstone = true"
+            )
+        }
+    }
+
+    @Test
+    fun deletedCatalogShouldNotBeReturnedByDefault() {
+        // Use a freshly created, dedicated catalog so that deleting it does not affect other tests.
+        val dedicatedCatalogId = "tombstone_cat_test"
+
+        // Create the dedicated catalog.
+        executeWrite(WriteRequest().add(Write().createMap(naksha.model.objects.NakshaCatalog(dedicatedCatalogId))))
+
+        // Verify it is visible before deletion.
+        newReadSession().use { session ->
+            assertNotNull(
+                session.getCatalogById(dedicatedCatalogId),
+                "Catalog should be visible before deletion"
+            )
+        }
+
+        // Delete the catalog (use executeWrite directly since this catalog was not created via initCatalog).
+        executeWrite(WriteRequest().add(Write().deleteMapById(dedicatedCatalogId)))
+
+        // Default call (allowTombstone = false) must return null.
+        newReadSession().use { session ->
+            assertNull(
+                session.getCatalogById(dedicatedCatalogId),
+                "Deleted catalog must NOT be returned when allowTombstone = false (default)"
+            )
+
+            // Explicit allowTombstone = true must return the tombstone entry.
+            assertNotNull(
+                session.getCatalogById(dedicatedCatalogId, allowTombstone = true),
+                "Deleted catalog MUST be returned when allowTombstone = true"
+            )
+        }
+    }
+}

--- a/here-naksha-lib-psql/src/commonTest/kotlin/naksha/psql/TestMap.kt
+++ b/here-naksha-lib-psql/src/commonTest/kotlin/naksha/psql/TestMap.kt
@@ -17,6 +17,9 @@ enum class TestMap(val id: String) {
     /** Shared map used by tests that do **not** request their own schema (`mapId = null`). */
     SHARED("naksha_psql_test"),
 
+    /** Dedicated map for [AllowTombstoneTest]. */
+    ALLOW_TOMBSTONE_TEST("allow_tombstone_test"),
+
     /** Dedicated map for [CollectionTests]. */
     COLLECTION_TESTS("collection_tests"),
 

--- a/here-naksha-lib-view/src/jvmMain/java/com/here/naksha/lib/view/ViewReadSession.java
+++ b/here-naksha-lib-view/src/jvmMain/java/com/here/naksha/lib/view/ViewReadSession.java
@@ -260,22 +260,28 @@ public class ViewReadSession implements IReadSession, AutoCloseable {
   }
 
   @Override
-  public @Nullable NakshaCatalog getCatalogById(@NotNull String catalogId) {
+  public @Nullable NakshaCatalog getCatalogById(@NotNull String catalogId, boolean allowTombstone) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public @Nullable NakshaCatalog getCatalogByNumber(int catalogNumber) {
+  public @Nullable NakshaCatalog getCatalogByNumber(int catalogNumber, boolean allowTombstone) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public @Nullable NakshaCollection getCollectionById(@NotNull NakshaCatalog map, @NotNull String collectionId) {
+  public @Nullable NakshaCollection getCollectionById(
+      @NotNull NakshaCatalog map,
+      @NotNull String collectionId,
+      boolean allowTombstone) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public @Nullable NakshaCollection getCollectionByNumber(@NotNull NakshaCatalog catalog, int collectionNumber) {
+  public @Nullable NakshaCollection getCollectionByNumber(
+      @NotNull NakshaCatalog catalog,
+      int collectionNumber,
+      boolean allowTombstone) {
     throw new UnsupportedOperationException();
   }
 

--- a/here-naksha-lib-view/src/jvmTest/java/com/here/naksha/lib/view/MockReadSession.java
+++ b/here-naksha-lib-view/src/jvmTest/java/com/here/naksha/lib/view/MockReadSession.java
@@ -102,22 +102,28 @@ public class MockReadSession implements IReadSession {
   }
 
   @Override
-  public @Nullable NakshaCatalog getCatalogById(@NotNull String catalogId) {
+  public @Nullable NakshaCatalog getCatalogById(@NotNull String catalogId, boolean allowTombstone) {
     return null;
   }
 
   @Override
-  public @Nullable NakshaCatalog getCatalogByNumber(int catalogNumber) {
+  public @Nullable NakshaCatalog getCatalogByNumber(int catalogNumber, boolean allowTombstone) {
     return null;
   }
 
   @Override
-  public @Nullable NakshaCollection getCollectionById(@NotNull NakshaCatalog map, @NotNull String collectionId) {
+  public @Nullable NakshaCollection getCollectionById(
+      @NotNull NakshaCatalog map,
+      @NotNull String collectionId,
+      boolean allowTombstone) {
     return null;
   }
 
   @Override
-  public @Nullable NakshaCollection getCollectionByNumber(@NotNull NakshaCatalog catalog, int collectionNumber) {
+  public @Nullable NakshaCollection getCollectionByNumber(
+      @NotNull NakshaCatalog catalog,
+      int collectionNumber,
+      boolean allowTombstone) {
     return null;
   }
 

--- a/here-naksha-storage-http/src/jvmMain/java/com/here/naksha/storage/http/HttpStorageReadSession.java
+++ b/here-naksha-storage-http/src/jvmMain/java/com/here/naksha/storage/http/HttpStorageReadSession.java
@@ -131,12 +131,12 @@ public class HttpStorageReadSession implements IReadSession {
   }
 
   @Override
-  public @Nullable NakshaCatalog getCatalogById(@NotNull String catalogId) {
+  public @Nullable NakshaCatalog getCatalogById(@NotNull String catalogId, boolean allowTombstone) {
     throw new NotImplementedException("Not supported by HTTP storage");
   }
 
   @Override
-  public @Nullable NakshaCatalog getCatalogByNumber(int catalogNumber) {
+  public @Nullable NakshaCatalog getCatalogByNumber(int catalogNumber, boolean allowTombstone) {
     return null;
   }
 
@@ -146,7 +146,10 @@ public class HttpStorageReadSession implements IReadSession {
   }
 
   @Override
-  public @Nullable NakshaCollection getCollectionByNumber(@NotNull NakshaCatalog catalog, int collectionNumber) {
+  public @Nullable NakshaCollection getCollectionByNumber(
+      @NotNull NakshaCatalog catalog,
+      int collectionNumber,
+      boolean allowTombstone) {
     throw new NotImplementedException("Not supported by HTTP storage");
   }
 
@@ -161,7 +164,10 @@ public class HttpStorageReadSession implements IReadSession {
   }
 
   @Override
-  public @Nullable NakshaCollection getCollectionById(@NotNull NakshaCatalog map, @NotNull String collectionId) {
+  public @Nullable NakshaCollection getCollectionById(
+      @NotNull NakshaCatalog map,
+      @NotNull String collectionId,
+      boolean allowTombstone) {
     // TODO: Technically, this translates into creating an ReadCollections query!
     throw new NotImplementedException("Not supported by HTTP storage");
   }


### PR DESCRIPTION
Fix tombstones for catalogs and collections. There is now an optional parameter `allowTombstone` that is false by default, therefore, when for example a catalog is deleted, the default `session.getCatalogById("foo")` will not return it, if tombstones are wished, it has now to be explicitly requested via `session.getCatalogById("foo", true)`.

This fix is based upon:

https://github.com/heremaps/naksha/pull/634#discussion_r3664891711